### PR TITLE
Add image metadata fields and export scripts (Issue #2)

### DIFF
--- a/src/components/image-processor/ImageCard.tsx
+++ b/src/components/image-processor/ImageCard.tsx
@@ -4,6 +4,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Trash2, Download, Loader2, FileImage, CheckCircle2 } from "lucide-react";
 import TagSelector from './TagSelector';
+import ImageMetadata from './ImageMetadata';
 
 interface ImageCardProps {
   image: ProcessedImage;
@@ -11,6 +12,7 @@ interface ImageCardProps {
   onRemove: () => void;
   onUpdateTags: (tags: string[]) => void;
   onAddGlobalTag: (tag: string) => void;
+  onUpdateMetadata: (metadata: Partial<Pick<ProcessedImage, 'title' | 'altText' | 'description' | 'caption'>>) => void;
 }
 
 const ImageCard: React.FC<ImageCardProps> = ({
@@ -19,6 +21,7 @@ const ImageCard: React.FC<ImageCardProps> = ({
   onRemove,
   onUpdateTags,
   onAddGlobalTag,
+  onUpdateMetadata,
 }) => {
   const formatSize = (bytes: number) => {
     if (bytes === 0) return '0 Bytes';
@@ -74,19 +77,19 @@ const ImageCard: React.FC<ImageCardProps> = ({
               <span className="text-[10px] text-slate-500 uppercase font-bold tracking-wider">
                 {formatSize(image.originalSize)}
               </span>
-              {image.optimizedSize && (
+              {image.optimisedSize && (
                 <>
                   <span className="text-slate-300">→</span>
                   <span className="text-[10px] text-green-600 font-bold tracking-wider">
-                    {formatSize(image.optimizedSize)}
+                    {formatSize(image.optimisedSize)}
                   </span>
                 </>
               )}
             </div>
           </div>
-          {image.optimizedUrl && (
+          {image.optimisedUrl && (
             <Button variant="outline" size="icon" className="h-8 w-8" asChild>
-              <a href={image.optimizedUrl} download={`optimized-${image.file.name.split('.')[0]}.webp`}>
+              <a href={image.optimisedUrl} download={`optimised-${image.file.name.split('.')[0]}.webp`}>
                 <Download className="h-4 w-4" />
               </a>
             </Button>
@@ -102,6 +105,11 @@ const ImageCard: React.FC<ImageCardProps> = ({
             onAddNewTag={onAddGlobalTag}
           />
         </div>
+
+        <ImageMetadata
+          image={image}
+          onUpdate={onUpdateMetadata}
+        />
       </CardContent>
     </Card>
   );

--- a/src/components/image-processor/ImageMetadata.tsx
+++ b/src/components/image-processor/ImageMetadata.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { ProcessedImage } from '@/hooks/use-image-store';
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+
+interface ImageMetadataProps {
+  image: ProcessedImage;
+  onUpdate: (metadata: Partial<Pick<ProcessedImage, 'title' | 'altText' | 'description' | 'caption'>>) => void;
+}
+
+const getFilenamePrefix = (filename: string): string => {
+  return filename.split('.').slice(0, -1).join('.') || filename;
+};
+
+const ImageMetadata: React.FC<ImageMetadataProps> = ({ image, onUpdate }) => {
+  const filenamePrefix = getFilenamePrefix(image.file.name);
+
+  const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onUpdate({ title: e.target.value });
+  };
+
+  const handleAltTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    onUpdate({ altText: e.target.value });
+  };
+
+  const handleCaptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    onUpdate({ caption: e.target.value });
+  };
+
+  const handleDescriptionChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    onUpdate({ description: e.target.value });
+  };
+
+  return (
+    <div className="pt-2 border-t border-slate-100 space-y-4">
+      <p className="text-[10px] font-bold text-slate-400 uppercase mb-3 tracking-widest">Metadata</p>
+      
+      <div className="space-y-2">
+        <Label htmlFor={`title-${image.id}`} className="text-xs font-medium text-slate-700">
+          Title
+        </Label>
+        <Input
+          id={`title-${image.id}`}
+          value={image.title || ''}
+          onChange={handleTitleChange}
+          placeholder={filenamePrefix}
+          className="h-8 text-xs"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`alt-${image.id}`} className="text-xs font-medium text-slate-700">
+          Alt-text
+        </Label>
+        <Textarea
+          id={`alt-${image.id}`}
+          value={image.altText || ''}
+          onChange={handleAltTextChange}
+          placeholder={filenamePrefix}
+          className="min-h-[60px] text-xs resize-none"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`caption-${image.id}`} className="text-xs font-medium text-slate-700">
+          Caption
+        </Label>
+        <Textarea
+          id={`caption-${image.id}`}
+          value={image.caption || ''}
+          onChange={handleCaptionChange}
+          placeholder="Enter caption..."
+          className="min-h-[60px] text-xs resize-none"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor={`description-${image.id}`} className="text-xs font-medium text-slate-700">
+          Description
+        </Label>
+        <Textarea
+          id={`description-${image.id}`}
+          value={image.description || ''}
+          onChange={handleDescriptionChange}
+          placeholder="Enter description..."
+          className="min-h-[100px] text-xs resize-none"
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ImageMetadata;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -27,6 +27,7 @@ const Index = () => {
     addGlobalTag,
     batchAddTags,
     clearAllTags,
+    updateImageMetadata,
     setImages
   } = useImageStore();
 
@@ -59,12 +60,12 @@ const Index = () => {
         type: `image/${settings.format}`,
       });
 
-      const optimizedUrl = URL.createObjectURL(finalFile);
+      const optimisedUrl = URL.createObjectURL(finalFile);
       
       updateImageStatus(image.id, 'completed', {
-        optimizedBlob: finalFile,
-        optimizedUrl,
-        optimizedSize: finalFile.size,
+        optimisedBlob: finalFile,
+        optimisedUrl,
+        optimisedSize: finalFile.size,
       });
     } catch (error) {
       console.error(error);
@@ -82,13 +83,13 @@ const Index = () => {
     }
     
     setIsProcessing(false);
-    showSuccess("All images optimized successfully!");
+    showSuccess("All images optimised successfully!");
   };
 
   const handleClearQueue = () => {
     images.forEach(img => {
       if (img.preview) URL.revokeObjectURL(img.preview);
-      if (img.optimizedUrl) URL.revokeObjectURL(img.optimizedUrl);
+      if (img.optimisedUrl) URL.revokeObjectURL(img.optimisedUrl);
     });
     setImages([]);
     showSuccess("Queue cleared.");
@@ -194,6 +195,7 @@ const Index = () => {
                       onRemove={() => removeImage(image.id)}
                       onUpdateTags={(tags) => updateImageTags(image.id, tags)}
                       onAddGlobalTag={addGlobalTag}
+                      onUpdateMetadata={(metadata) => updateImageMetadata(image.id, metadata)}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
- Add alt-text, title, description, and caption fields to images
- Create ImageMetadata component with form inputs for all metadata
- Initialize title and alt-text with filename prefix defaults
- Add updateImageMetadata function to store
- Generate CSV file with metadata (filename,title,alt,caption,description,tags)
- Generate bash script (import.sh) with wp media import commands
- Generate batch script (import.bat) with wp media import commands
- Include CSV and scripts in ZIP export
- Properly escape special characters for CSV, bash, and batch formats