### PR TITLE
Refactor: Simplify tags system and remove WP categories (Issue #13)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-checkbox':
+        specifier: ^1.3.3
+        version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-collapsible':
+        specifier: ^1.1.12
+        version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -398,6 +404,32 @@ packages:
 
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.3':
+    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.12':
+    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2098,6 +2130,38 @@ snapshots:
   '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.10
+      '@types/react-dom': 19.2.3(@types/react@19.2.10)
+
+  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.10)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.10
+      '@types/react-dom': 19.2.3(@types/react@19.2.10)
+
+  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.10)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.10)(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:

--- a/src/components/image-processor/ImageCard.tsx
+++ b/src/components/image-processor/ImageCard.tsx
@@ -1,26 +1,26 @@
 import React from 'react';
-import { ProcessedImage } from '@/hooks/use-image-store';
+import { ProcessedImage, TagsSettings } from '@/hooks/use-image-store';
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Trash2, Download, Loader2, FileImage, CheckCircle2 } from "lucide-react";
+import { Trash2, Download, Loader2, CheckCircle2, Tag } from "lucide-react";
 import TagSelector from './TagSelector';
 import ImageMetadata from './ImageMetadata';
 
 interface ImageCardProps {
   image: ProcessedImage;
-  availableTags: string[];
+  tagsSettings: TagsSettings;
   onRemove: () => void;
   onUpdateTags: (tags: string[]) => void;
-  onAddGlobalTag: (tag: string) => void;
+  onAddTagToSettings: (tag: string) => void;
   onUpdateMetadata: (metadata: Partial<Pick<ProcessedImage, 'title' | 'altText' | 'description' | 'caption'>>) => void;
 }
 
 const ImageCard: React.FC<ImageCardProps> = ({
   image,
-  availableTags,
+  tagsSettings,
   onRemove,
   onUpdateTags,
-  onAddGlobalTag,
+  onAddTagToSettings,
   onUpdateMetadata,
 }) => {
   const formatSize = (bytes: number) => {
@@ -37,6 +37,13 @@ const ImageCard: React.FC<ImageCardProps> = ({
       : [...image.tags, tag];
     onUpdateTags(newTags);
   };
+
+  const handleAddNewTag = (tag: string) => {
+    onAddTagToSettings(tag);
+    toggleTag(tag);
+  };
+
+  const availableTags = tagsSettings.tags;
 
   return (
     <Card className="overflow-hidden border-slate-200 hover:border-indigo-300 transition-colors group">
@@ -102,9 +109,10 @@ const ImageCard: React.FC<ImageCardProps> = ({
             selectedTags={image.tags}
             availableTags={availableTags}
             onToggleTag={toggleTag}
-            onAddNewTag={onAddGlobalTag}
+            onAddNewTag={handleAddNewTag}
           />
         </div>
+
 
         <ImageMetadata
           image={image}

--- a/src/components/image-processor/SettingsModal.tsx
+++ b/src/components/image-processor/SettingsModal.tsx
@@ -7,15 +7,18 @@ import {
 } from "@/components/ui/dialog";
 import ProcessingSettings from '@/components/image-processor/ProcessingSettings';
 import SSHSettings from '@/components/image-processor/SSHSettings';
-import { ProcessingSettings as ProcessingSettingsType, SSHSettings as SSHSettingsType } from '@/hooks/use-image-store';
+import TagsSettings from '@/components/image-processor/TagsSettings';
+import { ProcessingSettings as ProcessingSettingsType, SSHSettings as SSHSettingsType, TagsSettings as TagsSettingsType } from '@/hooks/use-image-store';
 
 interface SettingsModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   processingSettings: ProcessingSettingsType;
   sshSettings: SSHSettingsType;
+  tagsSettings: TagsSettingsType;
   onProcessingSettingsUpdate: (settings: ProcessingSettingsType) => void;
   onSshSettingsUpdate: (settings: SSHSettingsType) => void;
+  onTagsSettingsUpdate: (settings: TagsSettingsType) => void;
 }
 
 const SettingsModal: React.FC<SettingsModalProps> = ({
@@ -23,8 +26,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   onOpenChange,
   processingSettings,
   sshSettings,
+  tagsSettings,
   onProcessingSettingsUpdate,
   onSshSettingsUpdate,
+  onTagsSettingsUpdate,
 }) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -34,6 +39,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
         </DialogHeader>
         <div className="space-y-6 mt-4">
           <ProcessingSettings settings={processingSettings} onUpdate={onProcessingSettingsUpdate} />
+          <TagsSettings settings={tagsSettings} onUpdate={onTagsSettingsUpdate} />
           <SSHSettings settings={sshSettings} onUpdate={onSshSettingsUpdate} />
         </div>
       </DialogContent>

--- a/src/components/image-processor/TagsSettings.tsx
+++ b/src/components/image-processor/TagsSettings.tsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import { TagsSettings as Settings } from '@/hooks/use-image-store';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Plus, X, Tag, Info } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+interface TagsSettingsProps {
+  settings: Settings;
+  onUpdate: (settings: Settings) => void;
+}
+
+const TagsSettings: React.FC<TagsSettingsProps> = ({ settings, onUpdate }) => {
+  const [newTagName, setNewTagName] = useState('');
+
+  // Helper function to add a tag
+  const addTag = () => {
+    if (!newTagName.trim() || settings.tags.includes(newTagName.trim())) return;
+    onUpdate({ ...settings, tags: [...settings.tags, newTagName.trim()] });
+    setNewTagName('');
+  };
+
+  // Helper function to remove a tag
+  const removeTag = (tag: string) => {
+    onUpdate({ ...settings, tags: settings.tags.filter(t => t !== tag) });
+  };
+
+  return (
+    <Card className="border-slate-200 shadow-sm">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center gap-2">
+          <Tag className="h-5 w-5 text-indigo-600" />
+          Tags
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription className="text-xs leading-relaxed">
+            Configure the tags that will be available for selection when processing images. 
+            These tags can be used to organise and categorise your images.
+          </AlertDescription>
+        </Alert>
+
+        {/* Tags Section */}
+        <div className="space-y-3">
+          <Label className="text-sm font-medium">Available Tags</Label>
+          <div className="border border-slate-200 rounded-md p-3 bg-slate-50 max-h-48 overflow-y-auto">
+            {settings.tags.length === 0 ? (
+              <p className="text-xs text-slate-500 text-center py-4">No tags added yet</p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {settings.tags.map((tag) => (
+                  <div
+                    key={tag}
+                    className="flex items-center gap-1 bg-white border border-slate-200 rounded-md px-2 py-1 text-xs"
+                  >
+                    <span className="text-slate-700">{tag}</span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-4 w-4 p-0 hover:bg-slate-100"
+                      onClick={() => removeTag(tag)}
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Input
+              placeholder="Tag name"
+              value={newTagName}
+              onChange={(e) => setNewTagName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addTag();
+                }
+              }}
+              className="flex-1"
+            />
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={addTag}
+              disabled={!newTagName.trim() || settings.tags.includes(newTagName.trim())}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+          <p className="text-[10px] text-slate-500 leading-relaxed">
+            Add tags that will be available for selection when processing images. Press Enter or click the plus button to add.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TagsSettings;

--- a/src/components/image-processor/WPCategoriesTagsSettings.tsx
+++ b/src/components/image-processor/WPCategoriesTagsSettings.tsx
@@ -1,0 +1,285 @@
+import React, { useState } from 'react';
+import { WPCategoriesTagsSettings as Settings, WPCategoryNode } from '@/hooks/use-image-store';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { ChevronRight, ChevronDown, Plus, X, Folder, Tag, Info } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+
+interface WPCategoriesTagsSettingsProps {
+  settings: Settings;
+  onUpdate: (settings: Settings) => void;
+}
+
+const WPCategoriesTagsSettings: React.FC<WPCategoriesTagsSettingsProps> = ({ settings, onUpdate }) => {
+  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
+  const [newCategoryName, setNewCategoryName] = useState('');
+  const [newTagName, setNewTagName] = useState('');
+
+  // Helper function to generate unique keys for categories
+  const getCategoryPath = (node: WPCategoryNode, path: string = ''): string => {
+    const currentPath = path ? `${path} > ${node.name}` : node.name;
+    return currentPath;
+  };
+
+  // Helper function to find a category node by path
+  const findCategoryByPath = (categories: WPCategoryNode[], path: string): WPCategoryNode | null => {
+    const parts = path.split(' > ');
+    let current: WPCategoryNode[] = categories;
+    let found: WPCategoryNode | null = null;
+
+    for (const part of parts) {
+      found = current.find(cat => cat.name === part) || null;
+      if (!found) return null;
+      current = found.children || [];
+    }
+    return found;
+  };
+
+  // Helper function to add a category (supports nested paths like "Parent > Child")
+  const addCategory = () => {
+    if (!newCategoryName.trim()) return;
+
+    const categoryPath = newCategoryName.trim();
+    const parts = categoryPath.split(' > ').map(p => p.trim()).filter(p => p);
+    
+    if (parts.length === 0) return;
+
+    const updatedCategories = [...settings.categories];
+    
+    // Build the category tree from the path
+    let currentLevel = updatedCategories;
+    let currentPath = '';
+    
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const path = currentPath ? `${currentPath} > ${part}` : part;
+      
+      // Check if this category already exists
+      let existing = currentLevel.find(cat => cat.name === part);
+      
+      if (!existing) {
+        // Create new category
+        existing = { name: part };
+        currentLevel.push(existing);
+      }
+      
+      // Prepare for next level
+      if (!existing.children) {
+        existing.children = [];
+      }
+      currentLevel = existing.children;
+      currentPath = path;
+    }
+
+    onUpdate({ ...settings, categories: updatedCategories });
+    setNewCategoryName('');
+  };
+
+  // Helper function to remove a category
+  const removeCategory = (path: string) => {
+    const parts = path.split(' > ');
+    const updatedCategories = [...settings.categories];
+
+    if (parts.length === 1) {
+      // Root level category
+      onUpdate({ ...settings, categories: updatedCategories.filter(cat => cat.name !== parts[0]) });
+    } else {
+      // Nested category
+      const parentPath = parts.slice(0, -1).join(' > ');
+      const parent = findCategoryByPath(updatedCategories, parentPath);
+      if (parent && parent.children) {
+        parent.children = parent.children.filter(cat => cat.name !== parts[parts.length - 1]);
+        onUpdate({ ...settings, categories: updatedCategories });
+      }
+    }
+  };
+
+  // Helper function to add a tag
+  const addTag = () => {
+    if (!newTagName.trim() || settings.tags.includes(newTagName.trim())) return;
+    onUpdate({ ...settings, tags: [...settings.tags, newTagName.trim()] });
+    setNewTagName('');
+  };
+
+  // Helper function to remove a tag
+  const removeTag = (tag: string) => {
+    onUpdate({ ...settings, tags: settings.tags.filter(t => t !== tag) });
+  };
+
+  // Render category tree recursively
+  const renderCategoryTree = (categories: WPCategoryNode[], parentPath: string = '') => {
+    return categories.map((category) => {
+      const path = getCategoryPath(category, parentPath);
+      const isExpanded = expandedCategories.has(path);
+      const hasChildren = category.children && category.children.length > 0;
+
+      return (
+        <div key={path} className="ml-4">
+          <div className="flex items-center gap-2 py-1 group">
+            <Collapsible
+              open={isExpanded}
+              onOpenChange={(open) => {
+                const newExpanded = new Set(expandedCategories);
+                if (open) {
+                  newExpanded.add(path);
+                } else {
+                  newExpanded.delete(path);
+                }
+                setExpandedCategories(newExpanded);
+              }}
+            >
+              <div className="flex items-center gap-2 flex-1">
+                {hasChildren ? (
+                  <CollapsibleTrigger className="p-0.5 hover:bg-slate-100 rounded">
+                    {isExpanded ? (
+                      <ChevronDown className="h-4 w-4 text-slate-500" />
+                    ) : (
+                      <ChevronRight className="h-4 w-4 text-slate-500" />
+                    )}
+                  </CollapsibleTrigger>
+                ) : (
+                  <div className="w-5" />
+                )}
+                <Folder className="h-4 w-4 text-indigo-500" />
+                <span className="text-sm text-slate-700 flex-1">{category.name}</span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
+                  onClick={() => removeCategory(path)}
+                >
+                  <X className="h-3 w-3" />
+                </Button>
+              </div>
+              {hasChildren && (
+                <CollapsibleContent className="ml-6 mt-1">
+                  {renderCategoryTree(category.children!, path)}
+                </CollapsibleContent>
+              )}
+            </Collapsible>
+          </div>
+        </div>
+      );
+    });
+  };
+
+  return (
+    <Card className="border-slate-200 shadow-sm">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center gap-2">
+          <Tag className="h-5 w-5 text-indigo-600" />
+          Media Categories and Tags
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <Alert>
+          <Info className="h-4 w-4" />
+          <AlertDescription className="text-xs leading-relaxed">
+            To find your WordPress Attachment Categories and Tags, go to your WordPress admin → Media Library. 
+            Check the columns for "Att. Category" and "Att. Tag" to see the exact names. 
+            Ensure the spelling matches exactly what is in WordPress, and use a minimum of categories.
+          </AlertDescription>
+        </Alert>
+
+        {/* Categories Section */}
+        <div className="space-y-3">
+          <Label className="text-sm font-medium">Categories (Hierarchical)</Label>
+          <div className="border border-slate-200 rounded-md p-3 bg-slate-50 max-h-64 overflow-y-auto">
+            {settings.categories.length === 0 ? (
+              <p className="text-xs text-slate-500 text-center py-4">No categories added yet</p>
+            ) : (
+              <div className="space-y-1">
+                {renderCategoryTree(settings.categories)}
+              </div>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Input
+              placeholder="Category name (use 'Parent > Child' for nested)"
+              value={newCategoryName}
+              onChange={(e) => setNewCategoryName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addCategory();
+                }
+              }}
+              className="flex-1"
+            />
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={addCategory}
+              disabled={!newCategoryName.trim()}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+          <p className="text-[10px] text-slate-500 leading-relaxed">
+            Categories support hierarchical structure (parent/child relationships). 
+            Click the chevron to expand/collapse nested categories.
+          </p>
+        </div>
+
+        {/* Tags Section */}
+        <div className="space-y-3">
+          <Label className="text-sm font-medium">Tags (Simple List)</Label>
+          <div className="border border-slate-200 rounded-md p-3 bg-slate-50 max-h-48 overflow-y-auto">
+            {settings.tags.length === 0 ? (
+              <p className="text-xs text-slate-500 text-center py-4">No tags added yet</p>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {settings.tags.map((tag) => (
+                  <div
+                    key={tag}
+                    className="flex items-center gap-1 bg-white border border-slate-200 rounded-md px-2 py-1 text-xs"
+                  >
+                    <span className="text-slate-700">{tag}</span>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-4 w-4 p-0 hover:bg-slate-100"
+                      onClick={() => removeTag(tag)}
+                    >
+                      <X className="h-3 w-3" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Input
+              placeholder="Tag name"
+              value={newTagName}
+              onChange={(e) => setNewTagName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  addTag();
+                }
+              }}
+              className="flex-1"
+            />
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={addTag}
+              disabled={!newTagName.trim() || settings.tags.includes(newTagName.trim())}
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          </div>
+          <p className="text-[10px] text-slate-500 leading-relaxed">
+            Tags are simple labels. Add multiple tags separated by pressing Enter after each tag.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default WPCategoriesTagsSettings;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -19,6 +19,8 @@ const Index = () => {
     setSettings,
     sshSettings,
     setSshSettings,
+    tagsSettings,
+    setTagsSettings,
     addImages,
     removeImage,
     updateImageTags,
@@ -26,6 +28,7 @@ const Index = () => {
     addGlobalTag,
     batchAddTags,
     clearAllTags,
+    addTagToSettings,
     updateImageMetadata,
     setImages
   } = useImageStore();
@@ -139,7 +142,7 @@ const Index = () => {
           {/* Left Column: Export & Actions */}
           <div className="lg:col-span-4 space-y-6">
             <BatchActions 
-              availableTags={globalTags} 
+              availableTags={tagsSettings.tags} 
               onBatchAddTags={batchAddTags}
               onClearAllTags={clearAllTags}
               hasImages={images.length > 0}
@@ -199,10 +202,10 @@ const Index = () => {
                     <ImageCard
                       key={image.id}
                       image={image}
-                      availableTags={globalTags}
+                      tagsSettings={tagsSettings}
                       onRemove={() => removeImage(image.id)}
                       onUpdateTags={(tags) => updateImageTags(image.id, tags)}
-                      onAddGlobalTag={addGlobalTag}
+                      onAddTagToSettings={addTagToSettings}
                       onUpdateMetadata={(metadata) => updateImageMetadata(image.id, metadata)}
                     />
                   ))}
@@ -219,8 +222,10 @@ const Index = () => {
           onOpenChange={setSettingsOpen}
           processingSettings={settings}
           sshSettings={sshSettings}
+          tagsSettings={tagsSettings}
           onProcessingSettingsUpdate={setSettings}
           onSshSettingsUpdate={setSshSettings}
+          onTagsSettingsUpdate={setTagsSettings}
         />
       )}
     </div>


### PR DESCRIPTION
- Renamed WP Tags settings to Tags settings
- Removed WP category functionality
- Restored original tags functionality using image.tags field
- Removed wpCategory and wpTags fields from ProcessedImage
- Created simplified TagsSettings component (tags only, no categories)
- Updated ExportPanel to remove wp-cli category/tag parameters
- Updated CSV export to use tags instead of wp_tags/wp_category
- Maintained backward compatibility with tag migration

Co-authored-by: Cursor <cursoragent@cursor.com>